### PR TITLE
Avoid the possibility to create insecure directoriers in /tmp

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -2,6 +2,8 @@ cat << EOF  > "$archname"
 #!/bin/sh
 # This script was generated using Makeself $MS_VERSION
 
+umask 077
+
 CRCsum="$CRCsum"
 MD5="$MD5sum"
 TMPROOT=\${TMPDIR:=/tmp}


### PR DESCRIPTION
Depending on the umask options of the user running the script, a directory in /tmp could be created which allows unprivileged users write access.

Set umask in script to 077 to prevent potential privilege escalations
