### PR TITLE
Allow inclusion of license text

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -11,6 +11,7 @@ TMPROOT=\${TMPDIR:=/tmp}
 label="$LABEL"
 script="$SCRIPT"
 scriptargs="$SCRIPTARGS"
+licensetxt="$LICENSE"
 targetdir="$archdirname"
 filesizes="$filesizes"
 keep="$KEEP"
@@ -30,6 +31,25 @@ unset CDPATH
 MS_Printf()
 {
     \$print_cmd \$print_cmd_arg "\$1"
+}
+
+MS_PrintLicense()
+{
+  if test x"\$licensetxt" != x; then
+    echo \$licensetxt
+    while true
+    do
+      MS_Printf "Please type y to accept, n otherwise: "
+      read yn
+      if test x"\$yn" = xn; then
+        keep=n
+ 	eval \$finish; exit 1        
+        break;    
+      elif test x"\$yn" = xy; then
+        break;
+      fi
+    done
+  fi
 }
 
 MS_diskspace()
@@ -336,6 +356,8 @@ if test "\$quiet" = "y" -a "\$verbose" = "y";then
 	echo Cannot be verbose and quiet at the same time. >&2
 	exit 1
 fi
+
+MS_PrintLicense
 
 case "\$copy" in
 copy)

--- a/makeself.sh
+++ b/makeself.sh
@@ -116,6 +116,7 @@ MS_Usage()
     echo "    --nowait        : Do not wait for user input after executing embedded"
     echo "                      program from an xterm"
     echo "    --lsm file      : LSM file describing the package"
+    echo "    --license file  : Append a license file"
     echo
     echo "Do not forget to give a fully qualified startup script name"
     echo "(i.e. with a ./ prefix if inside the archive)."
@@ -196,6 +197,10 @@ do
 	HEADER="$2"
 	shift 2
 	;;
+    --license)
+        LICENSE=`cat $2`
+        shift 2
+        ;;
     --follow)
 	TAR_ARGS=cvfh
 	DU_ARGS=-ksL


### PR DESCRIPTION
This allows for the inclusion of some license text contained in a license file. The license will be displayed before extracting the contents of the package and installation will only continue if the user accepts the license agreement.
