### PR TITLE
Call du with quoted $archdir

### DIFF
--- a/makeself.sh
+++ b/makeself.sh
@@ -382,7 +382,7 @@ if test "$APPEND" = n; then
     fi
 fi
 
-USIZE=`du $DU_ARGS $archdir | awk '{print $1}'`
+USIZE=`du $DU_ARGS "$archdir" | awk '{print $1}'`
 DATE=`LC_ALL=C date`
 
 if test "." = "$archdirname"; then


### PR DESCRIPTION
du wasn't receiving $archdir in a quoted form, so paths with spaces
weren't being correctly handled, resulting in USIZE being null, which
eventually resulted in

```
if test $leftspace -lt ; then
```

being placed into the run script which would of course error when it
was run.
