### PR TITLE
Fix infinite loop when invoked incorrectly

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -289,7 +289,7 @@ EOLSM
 	--tar)
 	offset=\`head -n $SKIP "\$0" | wc -c | tr -d " "\`
 	arg1="\$2"
-	shift 2
+    if ! shift 2; then MS_Help; exit 1; fi
 	for s in \$filesizes
 	do
 	    MS_dd "\$0" \$offset \$s | eval "$GUNZIP_CMD" | tar "\$arg1" - \$*
@@ -316,7 +316,7 @@ EOLSM
     --target)
 	keep=y
 	targetdir=\${2:-.}
-	shift 2
+    if ! shift 2; then MS_Help; exit 1; fi
 	;;
     --noprogress)
 	noprogress=y

--- a/makeself.sh
+++ b/makeself.sh
@@ -201,16 +201,16 @@ do
     --target)
 	TARGETDIR="$2"
 	KEEP=y
-	shift 2
+    if ! shift 2; then MS_Help; exit 1; fi
 	;;
     --header)
 	HEADER="$2"
-	shift 2
+    if ! shift 2; then MS_Help; exit 1; fi
 	;;
     --license)
-        LICENSE=`cat $2`
-        shift 2
-        ;;
+    LICENSE=`cat $2`
+    if ! shift 2; then MS_Help; exit 1; fi
+    ;;
     --follow)
 	TAR_ARGS=cvfh
 	DU_ARGS=-ksL
@@ -241,7 +241,7 @@ do
 	;;
     --lsm)
 	LSM_CMD="cat \"$2\" >> \"\$archname\""
-	shift 2
+    if ! shift 2; then MS_Help; exit 1; fi
 	;;
     -q | --quiet)
 	QUIET=y


### PR DESCRIPTION
Description:
This commit fixes a case where certain shells (most noticeably bash)
do not shift anything at all if shift 2 is used and there are not
two arguments.
This caused an infinite loop when the installer was invoked
incorrectly if run under such a shell.

Now a usage message is displayed instead.

Author: Brian Carlson brian.carlson@cpanel.net
Bug-Cpanel: http://fogbugz.cpanel.net/default.asp?61069
