### PR TITLE
Minor usage fix, startup_script is mandatory.

### DIFF
--- a/makeself.sh
+++ b/makeself.sh
@@ -86,7 +86,7 @@ done
 
 MS_Usage()
 {
-    echo "Usage: $0 [params] archive_dir file_name label [startup_script] [args]"
+    echo "Usage: $0 [params] archive_dir file_name label startup_script [args]"
     echo "params can be one or more of the following :"
     echo "    --version | -v  : Print out Makeself version number and exit"
     echo "    --help | -h     : Print out this help message"


### PR DESCRIPTION
The script's usage is not consistent with the one in the readme. Tests show that the startup_script argument is not optional.
