### PR TITLE
added exclude vcs support, only tested on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The syntax of makeself is the following:
     * **--nomd5** and **--nocrc** : Disable the creation of a MD5 / CRC checksum for the archive. This speeds up the extraction process if integrity checking is not necessary.
     * **--lsm _file_** : Provide and LSM file to makeself, that will be embedded in the generated archive. LSM files are describing a software package in a way that is easily parseable. The LSM entry can then be later retrieved using the '-lsm' argument to the archive. An exemple of a LSM file is provided with Makeself.
     * **--tar-extra opt** : Append more options to the tar command line.
+    * **--exclude-vcs** : Exclude version control system directories.
 
   * _archive_dir_ is the name of the directory that contains the files to be archived
   * _file_name_ is the name of the archive to be created

--- a/makeself.sh
+++ b/makeself.sh
@@ -120,6 +120,7 @@ MS_Usage()
     echo "                      program from an xterm"
     echo "    --lsm file      : LSM file describing the package"
     echo "    --license file  : Append a license file"
+    echo "    --exclude-vcs   : Exclude version control system directories"
     echo
     echo "Do not forget to give a fully qualified startup script name"
     echo "(i.e. with a ./ prefix if inside the archive)."
@@ -142,6 +143,7 @@ NOPROGRESS=n
 COPY=none
 TAR_ARGS=cvf
 TAR_EXTRA=""
+EXCLUDE_VCS=""
 DU_ARGS=-ks
 HEADER=`dirname "$0"`/makeself-header.sh
 TARGETDIR=""
@@ -237,6 +239,10 @@ do
 	;;
     --nowait)
 	shift
+    ;;
+    --exclude-vcs)
+    EXCLUDE_VCS="--exclude-vcs"
+    shift
 	;;
     --nomd5)
 	NOMD5=y
@@ -417,7 +423,7 @@ if test "$QUIET" = "n";then
    echo Adding files to archive named \"$archname\"...
 fi
 exec 3<> "$tmpfile"
-(cd "$archdir" && ( tar $TAR_ARGS $TAR_EXTRA - . | eval "$GZIP_CMD" >&3 ) ) || { echo Aborting: Archive directory not found or temporary file: "$tmpfile" could not be created.; exec 3>&-; rm -f "$tmpfile"; exit 1; }
+(cd "$archdir" && ( tar $TAR_ARGS $TAR_EXTRA - . $EXCLUDE_VCS | eval "$GZIP_CMD" >&3 ) ) || { echo Aborting: Archive directory not found or temporary file: "$tmpfile" could not be created.; exec 3>&-; rm -f "$tmpfile"; exit 1; }
 exec 3>&- # try to close the archive
 
 fsize=`cat "$tmpfile" | wc -c | tr -d " "`


### PR DESCRIPTION
Hi Stephane, I doubt this is of use to you as its not portable (option doesnt exist in osx tar for e.g.) but still.

Thanks,
Damian.
