### PR TITLE
TAR_EXTRA doesn't work for long opts

### DIFF
--- a/makeself.sh
+++ b/makeself.sh
@@ -417,7 +417,7 @@ if test "$QUIET" = "n";then
    echo Adding files to archive named \"$archname\"...
 fi
 exec 3<> "$tmpfile"
-(cd "$archdir" && ( tar $TAR_ARGS $TAR_EXTRA - . | eval "$GZIP_CMD" >&3 ) ) || { echo Aborting: Archive directory not found or temporary file: "$tmpfile" could not be created.; exec 3>&-; rm -f "$tmpfile"; exit 1; }
+(cd "$archdir" && ( tar $TAR_EXTRA -$TAR_ARGS - . | eval "$GZIP_CMD" >&3 ) ) || { echo Aborting: Archive directory not found or temporary file: "$tmpfile" could not be created.; exec 3>&-; rm -f "$tmpfile"; exit 1; }
 exec 3>&- # try to close the archive
 
 fsize=`cat "$tmpfile" | wc -c | tr -d " "`


### PR DESCRIPTION
The tar-extra option does not work because tar apparently wants options in a specific order.  It appears that tar wants long opts to come before the short opts.  Also, it wants the sort opts to be prefixed with a - if long opts are present.  The following commit corrects this.
