### PR TITLE
Add environment variable USER_PWD

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -7,6 +7,7 @@ umask 077
 CRCsum="$CRCsum"
 MD5="$MD5sum"
 TMPROOT=\${TMPDIR:=/tmp}
+USER_PWD="\$PWD"; export USER_PWD
 
 label="$LABEL"
 script="$SCRIPT"


### PR DESCRIPTION
If the startup-script need the current working directory for the
user extracting the archive OLDPWD will work with most shells.
However, this is not always guaranteed to work.

This patch records the content of PWD at the time the
self-extracting script is run into USER_PWD.  The startup-script
can then more reliably use this environment variable.

This approach have been tested on different versions of HPUX, AIX,
Solaris, QNX Neutrino, Linux, and OS-X.
