### PR TITLE
License confirmation shown twice with --copy

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -359,7 +359,9 @@ if test x"\$quiet" = xy -a x"\$verbose" = xy; then
 	exit 1
 fi
 
-MS_PrintLicense
+if test x"\$copy" \!= xphase2; then
+    MS_PrintLicense
+fi
 
 case "\$copy" in
 copy)


### PR DESCRIPTION
If you run a self-extracting archive with --copy, the license check is run twice.

There's already a --phase2 option that checks if the script is being
run after extraction; adding a check to not show the license if we're in
Phase 2.
