### PR TITLE
extract information about file permissions

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -463,7 +463,7 @@ fi
 
 for s in \$filesizes
 do
-    if MS_dd_Progress "\$0" \$offset \$s | eval "$GUNZIP_CMD" | ( cd "\$tmpdir"; UnTAR x ) 1>/dev/null; then
+    if MS_dd_Progress "\$0" \$offset \$s | eval "$GUNZIP_CMD" | ( cd "\$tmpdir"; UnTAR xp ) 1>/dev/null; then
 		if test x"\$ownership" = xy; then
 			(PATH=/usr/xpg4/bin:\$PATH; cd "\$tmpdir"; chown -R \`id -u\` .;  chgrp -R \`id -g\` .)
 		fi


### PR DESCRIPTION
hzm@hzm-desktop2:$ mkdir -p temp/tmp
hzm@hzm-desktop2:$ chmod a+w temp/tmp

hzm@hzm-desktop2:$ makeself --nowait --nox11 --gzip --current ./temp  xxx.bin xxx
Header is 501 lines long

WARNING: Overwriting existing file: xxx.bin
About to compress 8 KB of data...
Adding files to archive named "xxx.bin"...
./
./tmp/
CRC: 2974516770
MD5: d5bf3f1a342095b5d2410a3e1221858b

Self-extractable archive "xxx.bin" successfully created.
hzm@hzm-desktop2:$ ls
temp  xxx.bin
hzm@hzm-desktop2:$ sh xxx.bin
Verifying archive integrity... All good.
Uncompressing xxx  100%  
hzm@hzm-desktop2:$ ls -l
total 20
drwxr-xr-x 3 hzm hzm  4096 Aug 23 18:00 temp
drwx------ 2 hzm hzm  4096 Aug 23 18:00 tmp <== permission is lost
-rwxr-xr-x 1 hzm hzm 11951 Aug 23 18:00 xxx.bin
hzm@hzm-desktop2:$ sh xxx.bin --tar xvpf 
./
./tmp/
hzm@hzm-desktop2:$ ls -l
total 20
drwxr-xr-x 3 hzm hzm  4096 Aug 23 18:00 temp
drwxrwxrwx 2 hzm hzm  4096 Aug 23 18:00 tmp    <== permission is reserved
-rwxr-xr-x 1 hzm hzm 11951 Aug 23 18:00 xxx.bin
