### PR TITLE
adding ssl support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ The syntax of makeself is the following:
     * **--pbzip2** : Use pbzip2 instead of gzip for better and faster compression on machines having multiple CPUs. The pbzip2 command must be available in the command path. It is recommended that the archive prefix be set to something like '.bz2.run', so that potential users know that they'll need bzip2 to extract it.
     * **--xz** : Use xz instead of gzip for better compression. The xz command must be available in the command path. It is recommended that the archive prefix be set to something like '.xz.run' for the archive, so that potential users know that they'll need xz to extract it.
     * **--base64** : Encode the archive to ASCII in Base64 format (base64 command required).
+    * **--gpg-encrypt** : Encrypt the archive using "gpg -ac -z $COMPRESS_LEVEL". This will prompt for a password to encrypt with. Assumes that potential users have gpg installed.
+    * **--ssl-encrypt** : Encrypt the archive using "openssl aes-256-cbc -a -salt". This will prompt for a password to encrypt with. Assumes that the potential users have openssl installed. 
     * **--compress** : Use the UNIX "compress" command to compress the data. This should be the default on all platforms that don't have gzip available.
     * **--nocomp** : Do not use any compression for the archive, which will then be an uncompressed TAR.
     * **--complevel** : Specify the compression level for gzip,bzip2,pbzip2 and xz. (default to 9)

--- a/makeself.sh
+++ b/makeself.sh
@@ -182,10 +182,14 @@ do
 	COMPRESS=base64
 	shift
 	;;
-    --encrypt)
+    --gpg-encrypt)
 	COMPRESS=gpg
 	shift
 	;;
+    --ssl-encrypt)
+        COMPRESS=openssl
+        shift
+        ;;
     --nocomp)
 	COMPRESS=none
 	shift
@@ -368,6 +372,10 @@ base64)
 gpg)
     GZIP_CMD="gpg -ac -z$COMPRESS_LEVEL"
     GUNZIP_CMD="gpg -d"
+    ;;
+openssl)
+    GZIP_CMD="openssl aes-256-cbc -a -salt"
+    GUNZIP_CMD="openssl aes-256-cbc -d -a"
     ;;
 Unix)
     GZIP_CMD="compress -cf"


### PR DESCRIPTION
This commit modifies the --encrypt argument to --gpg-encrypt and adds an --ssl-encrypt option. 

The openssl encrypt option will prompt for a passphrase on encrypt and on decrypt. 

I have tested this on linux and osx. This is a crossplatform encryption solution :)