### PR TITLE
Fixing tar --follow option breaking

### DIFF
--- a/makeself.sh
+++ b/makeself.sh
@@ -241,7 +241,7 @@ do
     if ! shift 2; then MS_Help; exit 1; fi
     ;;
     --follow)
-	TAR_ARGS=cvfh
+	TAR_ARGS=cvhf
 	DU_ARGS=-ksL
 	shift
 	;;
@@ -311,8 +311,8 @@ archname="$2"
 if test "$QUIET" = "y"; then
     if test "$TAR_ARGS" = "cvf"; then
 	TAR_ARGS="cf"
-    elif test "$TAR_ARGS" = "cvfh";then
-	TAR_ARGS="cfh"
+    elif test "$TAR_ARGS" = "cvhf";then
+	TAR_ARGS="chf"
     fi
 fi
 


### PR DESCRIPTION
The options added for --follow had something after the "f", which caused
the "h" to be interpreted as a filename. Fixed by moving the "f" to be
the last option in TAR_ARGS.