### PR TITLE
set original permissions for unpacked files

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -2,6 +2,7 @@ cat << EOF  > "$archname"
 #!/bin/sh
 # This script was generated using Makeself $MS_VERSION
 
+ORIG_UMASK=\`umask\`
 umask 077
 
 CRCsum="$CRCsum"
@@ -465,7 +466,7 @@ fi
 
 for s in \$filesizes
 do
-    if MS_dd_Progress "\$0" \$offset \$s | eval "$GUNZIP_CMD" | ( cd "\$tmpdir"; UnTAR xp ) 1>/dev/null; then
+    if MS_dd_Progress "\$0" \$offset \$s | eval "$GUNZIP_CMD" | ( cd "\$tmpdir"; umask \$ORIG_UMASK ; UnTAR xp ) 1>/dev/null; then
 		if test x"\$ownership" = xy; then
 			(PATH=/usr/xpg4/bin:\$PATH; cd "\$tmpdir"; chown -R \`id -u\` .;  chgrp -R \`id -g\` .)
 		fi


### PR DESCRIPTION
Currently the following scenario is broken:

  developer@dev-machine$ makeself.sh --notemp app/ app.run app

  ...

  root@user-machine# cd /opt && ~/Downloads/app.run
  user@user-machine$ /opt/app/bin/app
  bash: /opt/app/bin/app: Permission denied

The problem is that users on user-machine cannot access unpacked files,
since they are created with umask 077.

The proposed solution is to use the original umask for untar.