### PR TITLE
--packaging-date

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/bashunit"]
+	path = test/bashunit
+	url = https://github.com/djui/bashunit.git

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The syntax of makeself is the following:
     * **--nomd5** and **--nocrc** : Disable the creation of a MD5 / CRC checksum for the archive. This speeds up the extraction process if integrity checking is not necessary.
     * **--lsm _file_** : Provide and LSM file to makeself, that will be embedded in the generated archive. LSM files are describing a software package in a way that is easily parseable. The LSM entry can then be later retrieved using the '-lsm' argument to the archive. An exemple of a LSM file is provided with Makeself.
     * **--tar-extra opt** : Append more options to the tar command line.
-
+    * **--packaging-date date : Use provided string as the packaging date instead of the current date.
   * _archive_dir_ is the name of the directory that contains the files to be archived
   * _file_name_ is the name of the archive to be created
   * _label_ is an arbitrary text string describing the package. It will be displayed while extracting the files.

--- a/makeself.1
+++ b/makeself.1
@@ -87,6 +87,8 @@ Do not create a CRC32 checksum for the archive.
 .TP
 .B --lsm file
 LSM file describing the package.
+.B --packaging-date date
+Use provided string as the packaging date instead of the current date.
 .PD
 .SH "AUTHORS"
 .LP 

--- a/makeself.sh
+++ b/makeself.sh
@@ -66,8 +66,10 @@
 #           Added --noprogress to prevent showing the progress during the decompression (Guy Baconniere)
 #           Added --target dir to allow extracting directly to a target directory (Guy Baconniere)
 # - 2.2.0 : Many bugfixes, updates and contributions from users. Check out the project page on Github for the details.
+# - 2.2.1 : Option to specify packaging date to enable byte-for-byte reproducibility. (Marc Pawlowsky)
 #
 # (C) 1998-2013 by Stephane Peter <megastep@megastep.org>
+# Copyright 2016 by Marc Pawlowsky <marcpawl@gmail.com>
 #
 # This software is released under the terms of the GNU GPL version 2 and above
 # Please read the license at http://www.gnu.org/copyleft/gpl.html
@@ -125,6 +127,9 @@ MS_Usage()
     echo "    --lsm file         : LSM file describing the package"
     echo "    --license file     : Append a license file"
     echo "    --help-header file : Add a header to the archive's --help output"
+    echo "    --packaging-date date"
+    echo "                       : Use provided string as the packaging date"
+    echo "                         instead of the current date."
     echo
     echo "Do not forget to give a fully qualified startup script name"
     echo "(i.e. with a ./ prefix if inside the archive)."
@@ -151,6 +156,7 @@ TAR_EXTRA=""
 DU_ARGS=-ks
 HEADER=`dirname "$0"`/makeself-header.sh
 TARGETDIR=""
+DATE=`LC_ALL=C date`
 
 # LSM file stuff
 LSM_CMD="echo No LSM. >> \"\$archname\""
@@ -273,6 +279,10 @@ do
 	LSM_CMD="cat \"$2\" >> \"\$archname\""
     if ! shift 2; then MS_Help; exit 1; fi
 	;;
+    --packaging-date)
+	DATE="$2"
+	if ! shift 2; then MS_Help; exit 1; fi
+        ;;
     --help-header)
 	HELPHEADER=`sed -e "s/'/'\\\\\''/g" $2`
     if ! shift 2; then MS_Help; exit 1; fi
@@ -440,7 +450,6 @@ if test "$APPEND" = n; then
 fi
 
 USIZE=`du $DU_ARGS "$archdir" | awk '{print $1}'`
-DATE=`LC_ALL=C date`
 
 if test "." = "$archdirname"; then
 	if test "$KEEP" = n; then

--- a/test/datetest
+++ b/test/datetest
@@ -1,0 +1,131 @@
+#!/bin/bash 
+
+SUT=$(realpath $(dirname $0)/../makeself.sh)
+
+# Default behaviour is to insert the current date in the
+# generated file.
+testCurrentDate() {
+  # Setup
+  temp=`mktemp -d -t XXXXX`
+  cd ${temp}
+  mkdir src
+  touch src/startup.sh
+
+  # Exercise
+  expected=`LC_ALL=C date +"%b"`
+
+  ${SUT} src src.sh alabel startup.sh
+
+  # Validate
+  actual=`strings src.sh | grep packaging`
+  expected=`date +"%b"`
+  if [[ ${actual} == *${expected}* ]]
+  then
+    found=0
+  else
+    echo "Substring not found: ${expected} in ${actual}"
+    found=1
+  fi
+  assertEqual 0 ${found} 
+  
+  # Cleanup
+  cd -
+  rm -rf ${temp}
+}
+
+
+# A fixed packaging date can be inserted
+# into the generated package.  This way
+# the package may be recreated from
+# source and remain byte-for-bye 
+# identical.
+testDateSet() {
+  # Setup
+  temp=`mktemp -d -t XXXXX`
+  echo temp=${temp}
+  cd ${temp}
+  mkdir src
+  touch src/startup.sh
+
+  expected='Sat Mar  5 19:35:21 EST 2016'
+
+  # Exercise
+  ${SUT} --packaging-date "${expected}" \
+    src src.sh alabel startup.sh
+
+  # Validate
+  actual=`strings src.sh | grep "Date of packaging"`
+  echo "actual="${actual}
+  expected=`date +"%b"`
+  if [[ ${actual} == *${expected}* ]]
+  then
+    echo date set found
+    found=0
+  else
+    echo "Substring not found: ${expected} in ${actual}"
+    found=1
+  fi
+  assertEqual 0 ${found} 
+  
+  # Cleanup
+  cd -
+  rm -rf ${temp}
+}
+
+
+# Error if --packaging-date is passed as
+# an argument but the date is missing
+testPackagingDateNeedsParameter() {
+  # Setup
+  temp=`mktemp -d -t XXXXX`
+  echo temp=${temp}
+  cd ${temp}
+  mkdir src
+  touch src/startup.sh
+
+  # Exercise
+  ${SUT} --packaging-date  \
+    src src.sh alabel startup.sh || true
+  actual=`test -f src.sh`
+
+  # Validate
+  echo "actual="${actual}
+  assertNotEqual 0 ${actual}
+  
+  # Cleanup
+  cd -
+  rm -rf ${temp}
+}
+
+# With the dates set we can get a byte for
+# byte identical package.
+testByteforbyte()
+{
+  # Setup
+  temp=`mktemp -d -t XXXXX`
+  echo temp=${temp}
+  cd ${temp}
+  mkdir src
+  echo "COMMANDS GO HERE" > src/startup.sh
+
+  date='Sat Mar  3 19:35:21 EST 2016'
+
+  # Exercise
+  ${SUT} --packaging-date "${date}" --tar-extra "--mtime 20160303" \
+    src src.sh alabel startup.sh
+  mv src.sh first
+  ${SUT} --packaging-date "${date}" --tar-extra "--mtime 20160303" \
+    src src.sh alabel startup.sh
+  mv src.sh second
+
+  # Validate
+  cmp first second
+  rc=$?
+  assert $rc
+  
+  # Cleanup
+  cd -
+  rm -rf ${temp}
+}
+
+source bashunit/bashunit.bash


### PR DESCRIPTION
Enable setting of package date, so the package can be create multiple times from source and have byte for byte identical packages.

Needed when the package is part of a reproducible build.
