### PR TITLE
Fix issue #80 assigning encoded license file content

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -40,7 +40,7 @@ MS_Printf()
 MS_PrintLicense()
 {
   if test x"\$licensetxt" != x; then
-    echo "\$licensetxt"
+    echo "\$licensetxt" | base64 --decode | gunzip | less -e
     while true
     do
       MS_Printf "Please type y to accept, n otherwise: "

--- a/makeself.sh
+++ b/makeself.sh
@@ -250,7 +250,7 @@ do
         if ! shift 2; then MS_Help; exit 1; fi
 	;;
     --license)
-        LICENSE=`cat $2`
+        LICENSE=`cat $2 | gzip | base64`
         if ! shift 2; then MS_Help; exit 1; fi
     ;;
     --follow)


### PR DESCRIPTION
A softtware I was trying to package had a pretty large EULA file.
The EULA text contained characters that would require escaping.
A encoding the text allows assigning the script variable any content.
