### PR TITLE
Maintain Bourne compatibility

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -34,7 +34,8 @@ else
 fi
 	
 if test -d /usr/xpg4/bin; then
-    export PATH=/usr/xpg4/bin:\$PATH
+    PATH=/usr/xpg4/bin:\$PATH
+    export PATH
 fi
 
 unset CDPATH

--- a/makeself.sh
+++ b/makeself.sh
@@ -85,7 +85,8 @@ done
 
 # For Solaris systems
 if test -d /usr/xpg4/bin; then
-    export PATH=/usr/xpg4/bin:$PATH
+    PATH=/usr/xpg4/bin:$PATH
+    export PATH
 fi
 
 # Procedures


### PR DESCRIPTION
Older (all?) versions of Bourne don't support set-and-export in a single
operation.