### PR TITLE
Add --untar-extra

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -24,7 +24,6 @@ nooverwrite="$NOOVERWRITE"
 quiet="n"
 nodiskspace="n"
 export_conf="$EXPORT_CONF"
-untar_extra="$UNTAR_EXTRA"
 
 print_cmd_arg=""
 if type printf > /dev/null; then

--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -24,6 +24,7 @@ nooverwrite="$NOOVERWRITE"
 quiet="n"
 nodiskspace="n"
 export_conf="$EXPORT_CONF"
+untar_extra="$UNTAR_EXTRA"
 
 print_cmd_arg=""
 if type printf > /dev/null; then
@@ -214,10 +215,10 @@ MS_Check()
 UnTAR()
 {
     if test x"\$quiet" = xn; then
-		tar \$1vf - 2>&1 || { echo Extraction failed. > /dev/tty; kill -15 \$$; }
+		tar \$1 "$UNTAR_EXTRA" -vf - 2>&1 || { echo Extraction failed. > /dev/tty; kill -15 \$$; }
     else
 
-		tar \$1f - 2>&1 || { echo Extraction failed. > /dev/tty; kill -15 \$$; }
+		tar \$1 "$UNTAR_EXTRA" -f - 2>&1 || { echo Extraction failed. > /dev/tty; kill -15 \$$; }
     fi
 }
 

--- a/makeself.sh
+++ b/makeself.sh
@@ -125,6 +125,7 @@ MS_Usage()
     echo "    --current          : Files will be extracted to the current directory"
     echo "                         Both --current and --target imply --notemp"
     echo "    --tar-extra opt    : Append more options to the tar command line"
+    echo "    --untar-extra opt  : Append more options to the during the extraction of the tar archive"
     echo "    --nomd5            : Don't calculate an MD5 for archive"
     echo "    --nocrc            : Don't calculate a CRC for archive"
     echo "    --header file      : Specify location of the header script"
@@ -252,6 +253,10 @@ do
 	;;
     --tar-extra)
 	TAR_EXTRA="$2"
+        if ! shift 2; then MS_Help; exit 1; fi
+        ;;
+    --untar-extra)
+        UNTAR_EXTRA="$2"
         if ! shift 2; then MS_Help; exit 1; fi
         ;;
     --target)


### PR DESCRIPTION
Add support for an additional command line flag --untar-extra which is able to pass arbitrary arguments to tar during the UnTar command.  My use case is: ./makeself.sh --gpg-asymmetric-encrypt-sign --complevel 0 --gpg-extra "--default-key XXXXXX -r XXXXXX --local-user XXXXXX" --tar-extra "--use-compress-program=xz -e -T 0 -9" --untar-extra "-J" ../things  Things.run  "\n Things.run \n" ./install.sh