### PR TITLE
Prepend error message in UnTAR() with `...' to make it more readable

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -218,7 +218,7 @@ MS_Check()
 UnTAR()
 {
     if test x"\$quiet" = xn; then
-		tar \$1 "$UNTAR_EXTRA" -vf - 2>&1 || { echo Extraction failed. > /dev/tty; kill -15 \$$; }
+		tar \$1 "$UNTAR_EXTRA" -vf - 2>&1 || { echo " ... Extraction failed." > /dev/tty; kill -15 \$$; }
     else
 
 		tar \$1 "$UNTAR_EXTRA" -f - 2>&1 || { echo Extraction failed. > /dev/tty; kill -15 \$$; }


### PR DESCRIPTION
Out of curiosity, I mv'ed tar for a while and run my program ./repo
created with makeself to see what would happen.  I noticed that
`Extraction failed' part is not well readable so I decided to make
this little patch to fix it.