### PR TITLE
Return to tar args that work for Solaris

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -218,10 +218,9 @@ MS_Check()
 UnTAR()
 {
     if test x"\$quiet" = xn; then
-		tar \$1 "$UNTAR_EXTRA" -vf - 2>&1 || { echo " ... Extraction failed." > /dev/tty; kill -15 \$$; }
+		tar \$1vf - $UNTAR_EXTRA 2>&1 || { echo " ... Extraction failed." > /dev/tty; kill -15 \$$; }
     else
-
-		tar \$1 "$UNTAR_EXTRA" -f - 2>&1 || { echo Extraction failed. > /dev/tty; kill -15 \$$; }
+		tar \$1f - $UNTAR_EXTRA 2>&1 || { echo Extraction failed. > /dev/tty; kill -15 \$$; }
     fi
 }
 


### PR DESCRIPTION
Address issue #106. This should still work with the added UNTAR_EXTRA feature, but returns to the known-working tar invocation for rickety old Solaris.

I took the liberty of dropping an extra empty line and the quotes around UNTAR_EXTRA so as to preempt any multi-arg problems.