### PR TITLE
Fix `--tar-extra` to accept multiple tar options

### DIFF
--- a/makeself.sh
+++ b/makeself.sh
@@ -529,7 +529,8 @@ if test "$QUIET" = "n";then
    echo Adding files to archive named \"$archname\"...
 fi
 exec 3<> "$tmpfile"
-(cd "$archdir" && ( tar "$TAR_EXTRA" -$TAR_ARGS - . | eval "$GZIP_CMD" >&3 ) ) || { echo Aborting: Archive directory not found or temporary file: "$tmpfile" could not be created.; exec 3>&-; rm -f "$tmpfile"; exit 1; }
+( cd "$archdir" && ( tar $TAR_EXTRA -$TAR_ARGS - . | eval "$GZIP_CMD" >&3 ) ) || \
+    { echo Aborting: archive directory not found or temporary file: "$tmpfile" could not be created.; exec 3>&-; rm -f "$tmpfile"; exit 1; }
 exec 3>&- # try to close the archive
 
 fsize=`cat "$tmpfile" | wc -c | tr -d " "`
@@ -617,4 +618,3 @@ else
     fi
 fi
 rm -f "$tmpfile"
-


### PR DESCRIPTION
Hi @megastep 

This PR fixes regression made after release [2.3.0](https://github.com/megastep/makeself/tree/release-2.3.0).
Previously it was possible to specify multiple `tar` options like this:
```bash
makeself.sh --bla --bla --tar-extra "--tar-opt-1 --tar-opt-2" archive_dir ...
```

Now that is broken by #98. Following changes will bring back the functionality available in release `2.3.0`.

Thanks for this awesome tool.