### PR TITLE
Add unit test for `--tar-extra` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ script:
   - cd test
   - ./datetest
   - ./extracttest
+  - ./tarextratest

--- a/test/tarextratest
+++ b/test/tarextratest
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+SUT=$(realpath "$(dirname "$0")/../makeself.sh")
+
+setupTests() {
+  temp=$(mktemp -d -t XXXXX)
+  pushd "${temp}"
+  mkdir -p src/.git
+  echo "echo This is a test" > src/startup.sh
+}
+
+tearDown() {
+  popd
+  rm -rf "${temp}"
+}
+
+testTarExtraOpts() {
+  setupTests
+
+  tar_extra="--verbose --exclude .git"
+  ${SUT} --tar-extra "$tar_extra" src src.sh alabel startup.sh
+
+  assert $?
+
+  tearDown
+}
+
+source bashunit/bashunit.bash


### PR DESCRIPTION
This PR is a follow-up for #108. It adds unit test for preventing further regressions.
The test is compatible with GNU and BSD `tar` implementations. 