### PR TITLE
Improve handling of complex license texts

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -50,7 +50,7 @@ MS_Printf()
 MS_PrintLicense()
 {
   if test x"\$licensetxt" != x; then
-    echo "\$licensetxt"
+    echo "\$licensetxt" | more
     if test x"\$accept" != xy; then
       while true
       do

--- a/makeself.sh
+++ b/makeself.sh
@@ -295,7 +295,8 @@ do
         if ! shift 2; then MS_Help; exit 1; fi
 	;;
     --license)
-        LICENSE=`cat $2`
+        # We need to escape all characters having a special meaning in double quotes
+        LICENSE=$(sed 's/\\/\\\\/g; s/"/\\\"/g; s/`/\\\`/g; s/\$/\\\$/g' $2)
         if ! shift 2; then MS_Help; exit 1; fi
 	;;
     --follow)


### PR DESCRIPTION
I stumbled into the same issue #82 user @nmontmarquette tried to solve in pull request #83. This is a more portable fix that escapes all characters having a special meaning in double quotes; hopefully I got all of them…