### PR TITLE
Support base64 decoding on MacOS X

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -34,7 +34,7 @@ elif test -x /usr/ucb/echo; then
 else
     print_cmd="echo"
 fi
-	
+
 if test -d /usr/xpg4/bin; then
     PATH=/usr/xpg4/bin:\$PATH
     export PATH

--- a/makeself.sh
+++ b/makeself.sh
@@ -466,7 +466,7 @@ lz4)
     ;;
 base64)
     GZIP_CMD="base64"
-    GUNZIP_CMD="base64 -d -i"
+    GUNZIP_CMD="base64 --decode -i -"
     ;;
 gpg)
     GZIP_CMD="gpg $GPG_EXTRA -ac -z$COMPRESS_LEVEL"


### PR DESCRIPTION
This PR allows scripts encoded with `base64` to be extracted on Linux and MacOS X.

## An issue
I have created a makeself archive in Linux, but unable to extract it on MacOS X:
```
$ ./archive.run --target tmp
Creating directory tmp
Verifying archive integrity...  100%   All good.
Uncompressing archivebase64: invalid option -- d
Usage:    base64 [-hvD] [-b num] [-i in_file] [-o out_file]
 -h, --help     display this message
 -D, --decode   decodes input
 -b, --break    break encoded string into num character lines
 -i, --input    input file (default: "-" for stdin)
 -o, --output   output file (default: "-" for stdout)
Extraction failed.
```

## Changes
Used common long option `--decode` of `base64` utility and explicitly read from `stdin`. 