### PR TITLE
Use `rm` from PATH

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -544,7 +544,7 @@ if test x"\$quiet" = xn; then
 fi
 res=3
 if test x"\$keep" = xn; then
-    trap 'echo Signal caught, cleaning up >&2; cd "\$TMPROOT"; /bin/rm -rf "\$tmpdir"; eval \$finish; exit 15' 1 2 3 15
+    trap 'echo Signal caught, cleaning up >&2; cd "\$TMPROOT"; rm -rf "\$tmpdir"; eval \$finish; exit 15' 1 2 3 15
 fi
 
 if test x"\$nodiskspace" = xn; then
@@ -610,7 +610,7 @@ if test x"\$script" != x; then
 fi
 if test x"\$keep" = xn; then
     cd "\$TMPROOT"
-    /bin/rm -rf "\$tmpdir"
+    rm -rf "\$tmpdir"
 fi
 eval \$finish; exit \$res
 EOF


### PR DESCRIPTION
On NixOS (a Linux distribution), there is no `/bin/rm`, but an `rm` command will generally be available in one's path when running shell scripts.  Here, I change a couple of invocations of `/bin/rm` into invocations of `rm` to deal with this issue.

Since `rm` is already called elsewhere in the script without an absolute path, I assume this change will not cause any regressions.  Still, I've tested this on a CentOS machine and a NixOS machine, though not other platforms.