### PR TITLE
Fix unit tests so they fail when there are failures

### DIFF
--- a/test/appendtest
+++ b/test/appendtest
@@ -22,7 +22,7 @@ testGzip()
   setupTests --gzip
   
   ./makeself-test.run --check
-  assert "-e $?"
+  assertEqual $? 0
 }
 
 

--- a/test/appendtest
+++ b/test/appendtest
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+SUT=$(realpath $(dirname $0)/../makeself.sh)
+SOURCE=$(realpath ..)
+
+setupTests() {
+  temp=`mktemp -d -t XXXXX`
+  cd "$temp"
+  cd "$temp"
+  mkdir archive
+  cp -a $SOURCE archive/ 
+  $SUT $* archive makeself-test.run "Test $*" echo Testing --tar-extra="--exclude .git" 
+  mkdir -p append/append_dir/
+  cp -a $SOURCE/makeself.sh append/append_dir/
+  $SUT --append append/ makeself-test.run
+
+}
+
+
+testGzip()
+{
+  setupTests --gzip
+  
+  ./makeself-test.run --check
+  assert "-e $?"
+}
+
+
+source bashunit/bashunit.bash

--- a/test/extracttest
+++ b/test/extracttest
@@ -17,7 +17,7 @@ testQuiet()
   setupTests
 
   ./makeself-test.run --quiet
-  assert $?
+  assertEqual $? 0
 }
 
 testGzip()
@@ -25,7 +25,7 @@ testGzip()
   setupTests --gzip
   
   ./makeself-test.run --check
-  assert $?
+  assertEqual $? 0
 }
 
 testBzip2()
@@ -33,7 +33,7 @@ testBzip2()
   setupTests --bzip2
   
   ./makeself-test.run --check
-  assert $?
+  assertEqual $? 0
 }
 
 testPBzip2()
@@ -41,7 +41,7 @@ testPBzip2()
   setupTests --pbzip2
 
   ./makeself-test.run --check
-  assert $?
+  assertEqual $? 0
 }
 
 

--- a/test/tarextratest
+++ b/test/tarextratest
@@ -20,7 +20,7 @@ testTarExtraOpts() {
   tar_extra="--verbose --exclude .git"
   ${SUT} --tar-extra "$tar_extra" src src.sh alabel startup.sh
 
-  assert $?
+  assertEqual $? 0
 
   tearDown
 }


### PR DESCRIPTION
an "assert $?" really just says "assert 1" (or some non-zero number) on a failure. Bashunit treats this as a success. This fixes them so it checks is the return value is 0.

This also adds a test to for the --append argument, which also fails, as seen in #48 It doesn't fix the issue, I may or may not be able to do that