### PR TITLE
disable showing license page by page when --accept option is used

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -58,7 +58,11 @@ MS_Printf()
 MS_PrintLicense()
 {
   if test x"\$licensetxt" != x; then
-    echo "\$licensetxt" | more
+    if test x"\$accept" = xy; then
+      echo "\$licensetxt"
+    else
+      echo "\$licensetxt" | more
+    fi
     if test x"\$accept" != xy; then
       while true
       do


### PR DESCRIPTION
The option --accept was introduced to support automated scripts. As our software license is quite long it will be shown page by page, where space need to be pressed to continue with the next page. This is extremely helpful, when the user has to accept the license himself.

However in cases of automated scripts this is not working. Therefore I have introduced a change, that when the --accept option which was introduced in #100 is used, that the license is shown completely without having to press any additional button.