### PR TITLE
Make xargs handle filenames that contain spaces

### DIFF
--- a/makeself.sh
+++ b/makeself.sh
@@ -581,7 +581,7 @@ fi
 tmparch="${TMPDIR:-/tmp}/mkself$$.tar"
 (
     cd "$archdir"
-    find . ! -type d | LC_ALL=C sort | xargs tar $TAR_EXTRA -$TAR_ARGS "$tmparch"
+    find . ! -type d | LC_ALL=C sort | xargs -d '\n' tar $TAR_EXTRA -$TAR_ARGS "$tmparch"
 ) || {
     echo "ERROR: failed to create temporary archive: $tmparch"
     rm -f "$tmparch" "$tmpfile"


### PR DESCRIPTION
Given that I was not able to create a self-extractable archive based on an archive dir containing spaces in filenames, I propose the fix. 