### PR TITLE
stable sort, even with whitespace paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
 - "./extracttest"
 - "./tarextratest"
 - "./appendtest"
+- "./whitespacetest"
 - cd ..
 deploy:
   provider: releases

--- a/makeself.sh
+++ b/makeself.sh
@@ -581,7 +581,10 @@ fi
 tmparch="${TMPDIR:-/tmp}/mkself$$.tar"
 (
     cd "$archdir"
-    find . ! -type d -print0 | LC_ALL=C sort | tr -d '\n' | xargs -0 tar $TAR_EXTRA -$TAR_ARGS "$tmparch"
+    find . ! -type d \
+        | LC_ALL=C sort \
+        | sed 's/./\\&/g' \
+        | xargs tar $TAR_EXTRA -$TAR_ARGS "$tmparch"
 ) || {
     echo "ERROR: failed to create temporary archive: $tmparch"
     rm -f "$tmparch" "$tmpfile"

--- a/test/whitespacetest
+++ b/test/whitespacetest
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+THIS="$(readlink -f "$0")"
+HERE="$(dirname "${THIS}")"
+SUT="$(dirname "${HERE}")/makeself.sh"
+
+testWhiteSpace() {
+    local archive_dir="$(mktemp -dt archive_dir.XXXXXX)"
+    (
+        cd "${archive_dir}"
+        touch "$(printf "_\x09_character_tabulation.txt")"
+        touch "$(printf "_\x0b_line_tabulation.txt")"
+        touch "$(printf "_\x0c_form_feed.txt")"
+        touch "$(printf "_\x0d_carriage_return.txt")"
+        touch "$(printf "_\x20_space:.txt")"
+    )
+    local file_name="$(mktemp -t file_name.XXXXXX)"
+    "${SUT}" "${archive_dir}" "${file_name}" "white space test" "ls -lah ."
+    assertEqual $? 0
+    rm -rf "${archive_dir}" "${file_name}"
+}
+
+source "${HERE}/bashunit/bashunit.bash"


### PR DESCRIPTION
* don't use `xargs -0` because it's not well supported

* use `sed 's/./\\&/g'` to properly quote whitespace in paths

* add test unit for whitespace-containing paths

This patch addresses comments made in github pull request #151 regarding
whitespace-containing filenames and stable sorted inputs.

References on lacking `xargs -0`:

* http://nixdoc.net/man-pages/HP-UX/man1/xargs.1.html

* http://nixdoc.net/man-pages/IRIX/man1/xargs.1.html

* http://nixdoc.net/man-pages/Tru64/man1/xargs.1.html

* https://www.unix.com/man-page/sunos/1/xargs

References on using find with xargs:

* http://www.etalabs.net/sh_tricks.html