### PR TITLE
Include empty dirs in archive -- Fix #175

### DIFF
--- a/makeself.sh
+++ b/makeself.sh
@@ -595,7 +595,7 @@ tmparch="${TMPDIR:-/tmp}/mkself$$.tar"
         tail -n +$OLDSKIP "$archname" | $GUNZIP_CMD > "$tmparch"
     fi
     cd "$archdir"
-    find . -mindepth 1 \
+    find . ! -type d -o -links 2 \
         | LC_ALL=C sort \
         | sed 's/./\\&/g' \
         | xargs tar $TAR_EXTRA -$TAR_ARGS "$tmparch"

--- a/makeself.sh
+++ b/makeself.sh
@@ -595,7 +595,7 @@ tmparch="${TMPDIR:-/tmp}/mkself$$.tar"
         tail -n +$OLDSKIP "$archname" | $GUNZIP_CMD > "$tmparch"
     fi
     cd "$archdir"
-    find . ! -type d \
+    find . -mindepth 1 \
         | LC_ALL=C sort \
         | sed 's/./\\&/g' \
         | xargs tar $TAR_EXTRA -$TAR_ARGS "$tmparch"


### PR DESCRIPTION
Remove the `! -type d` search parameters from the `find` call and replace it with `-mindepth 1`.

Sole effect should be to include empty directories within the target tree in the self-extracting archive.