### PR TITLE
script & args -> startup command, fix #171

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,14 @@ addons:
 script:
 - ./make-release.sh
 - cd test
+- "./appendtest"
 - "./datetest"
 - "./extracttest"
+- "./startupcommandtest"
 - "./suidtest"
 - "./tarextratest"
-- "./appendtest"
-- "./whitespacetest"
 - "./whitespacelicense"
+- "./whitespacetest"
 - cd ..
 deploy:
   provider: releases

--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -601,14 +601,15 @@ if test x"\$startup_command" != x; then
         export MS_ARCHDIRNAME MS_KEEP MS_NOOVERWRITE MS_COMPRESS
     fi
 
+    eval "set -- \$startup_command \$@"
     if test x"\$verbose" = x"y"; then
-		MS_Printf "OK to execute: \$script \$scriptargs \$* ? [Y/n] "
+		MS_Printf "OK to execute: \$(echo \$@ | xargs) ? [Y/n] "
 		read yn
 		if test x"\$yn" = x -o x"\$yn" = xy -o x"\$yn" = xY; then
-            eval "\$startup_command \"\\\$@\""; res=\$?
+            sh -c "\$(echo \$@ | xargs)"
 		fi
     else
-        eval "\$startup_command \"\\\$@\""; res=\$?
+        sh -c "\$(echo \$@ | xargs)"
     fi
     if test "\$res" -ne 0; then
         if test x"\$verbose" = xy; then

--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -606,14 +606,14 @@ if test x"\$startup_command" != x; then
 		MS_Printf "OK to execute: \$(echo \$@ | xargs) ? [Y/n] "
 		read yn
 		if test x"\$yn" = x -o x"\$yn" = xy -o x"\$yn" = xY; then
-            sh -c "\$(echo \$@ | xargs)"
+            sh -c "\$(echo \$@ | xargs)"; res=\$?
 		fi
     else
-        sh -c "\$(echo \$@ | xargs)"
+        sh -c "\$(echo \$@ | xargs)"; res=\$?
     fi
     if test "\$res" -ne 0; then
         if test x"\$verbose" = xy; then
-            echo "The command '\$startup_command' returned an error code (\$res)" >&2
+            echo "The command \"\$(echo \$@ | xargs)\" returned an error code (\$res)" >&2
         fi
     fi
 fi

--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -145,20 +145,20 @@ MS_Help()
 \${helpheader}Makeself version $MS_VERSION
  1) Getting help or info about \$0 :
   \$0 --help   Print this message
-  \$0 --info   Print embedded info : title, default target directory, embedded script ...
+  \$0 --info   Print embedded info : title, default target directory, embedded command ...
   \$0 --lsm    Print embedded lsm entry (or no LSM)
   \$0 --list   Print the list of files in the archive
   \$0 --check  Checks integrity of the archive
 
  2) Running \$0 :
-  \$0 [options] [--] [additional arguments to embedded script]
+  \$0 [options] [--] [additional arguments to embedded command]
   with following options (in that order)
-  --confirm             Ask before running embedded script
+  --confirm             Ask before running embedded command
   --quiet               Do not print anything except error messages
   --accept              Accept the license
-  --noexec              Do not run embedded script
+  --noexec              Do not run embedded command
   --keep                Do not erase target directory after running
-                        the embedded script
+                        the embedded command
   --noprogress          Do not show the progress during the decompression
   --nox11               Do not spawn an xterm
   --nochown             Do not give the target folder to the current user
@@ -171,7 +171,7 @@ MS_Help()
                         using OpenSSL. See "PASS PHRASE ARGUMENTS" in man openssl.
                         Default is to prompt the user to enter decryption password
                         on the current terminal.
-  --                    Following arguments will be passed to the embedded script
+  --                    Following arguments will be passed to the embedded command
 EOH
 }
 
@@ -380,7 +380,7 @@ EOLSM
 	shift
 	;;
 	--noexec)
-	script=""
+	startup_command=""
 	shift
 	;;
     --keep)
@@ -597,7 +597,7 @@ if test x"\$startup_command" != x; then
         MS_KEEP="\$KEEP"
         MS_NOOVERWRITE="\$NOOVERWRITE"
         MS_COMPRESS="\$COMPRESS"
-        export MS_BUNDLE MS_LABEL MS_SCRIPT MS_SCRIPTARGS
+        export MS_BUNDLE MS_LABEL MS_STARTUP_COMMAND
         export MS_ARCHDIRNAME MS_KEEP MS_NOOVERWRITE MS_COMPRESS
     fi
 

--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -15,8 +15,7 @@ TMPROOT=\${TMPDIR:=/tmp}
 USER_PWD="\$PWD"; export USER_PWD
 
 label="$LABEL"
-script="$SCRIPT"
-scriptargs="$SCRIPTARGS"
+startup_command=$(quote "$STARTUP_COMMAND")
 licensetxt="$LICENSE"
 helpheader='$HELPHEADER'
 targetdir="$archdirname"
@@ -311,10 +310,10 @@ do
 	fi
 	echo Date of packaging: $DATE
 	echo Built with Makeself version $MS_VERSION on $OSTYPE
-	echo Build command was: "$MS_COMMAND"
-	if test x"\$script" != x; then
-	    echo Script run after extraction:
-	    echo "    " \$script \$scriptargs
+	echo Build command was: $MS_COMMAND
+	if test x"\$startup_command" != x; then
+	    echo Command run after extraction:
+	    echo "    \$(echo \$startup_command | xargs)"
 	fi
 	if test x"$copy" = xcopy; then
 		echo "Archive will copy itself to a temporary location"
@@ -331,8 +330,7 @@ do
 	;;
     --dumpconf)
 	echo LABEL=\"\$label\"
-	echo SCRIPT=\"\$script\"
-	echo SCRIPTARGS=\"\$scriptargs\"
+	echo STARTUP_COMMAND=\"\$startup_command\"
 	echo archdirname=\"$archdirname\"
 	echo KEEP=$KEEP
 	echo NOOVERWRITE=$NOOVERWRITE
@@ -590,12 +588,11 @@ fi
 
 cd "\$tmpdir"
 res=0
-if test x"\$script" != x; then
+if test x"\$startup_command" != x; then
     if test x"\$export_conf" = x"y"; then
         MS_BUNDLE="\$0"
         MS_LABEL="\$label"
-        MS_SCRIPT="\$script"
-        MS_SCRIPTARGS="\$scriptargs"
+        MS_STARTUP_COMMAND="\$startup_command"
         MS_ARCHDIRNAME="\$archdirname"
         MS_KEEP="\$KEEP"
         MS_NOOVERWRITE="\$NOOVERWRITE"
@@ -608,13 +605,15 @@ if test x"\$script" != x; then
 		MS_Printf "OK to execute: \$script \$scriptargs \$* ? [Y/n] "
 		read yn
 		if test x"\$yn" = x -o x"\$yn" = xy -o x"\$yn" = xY; then
-			eval "\"\$script\" \$scriptargs \"\\\$@\""; res=\$?;
+            eval "\$startup_command \"\\\$@\""; res=\$?
 		fi
     else
-		eval "\"\$script\" \$scriptargs \"\\\$@\""; res=\$?
+        eval "\$startup_command \"\\\$@\""; res=\$?
     fi
     if test "\$res" -ne 0; then
-		test x"\$verbose" = xy && echo "The program '\$script' returned an error code (\$res)" >&2
+        if test x"\$verbose" = xy; then
+            echo "The command '\$startup_command' returned an error code (\$res)" >&2
+        fi
     fi
 fi
 if test x"\$keep" = xn; then

--- a/makeself.sh
+++ b/makeself.sh
@@ -89,7 +89,7 @@ save () {
 
 MS_Usage()
 {
-    echo "Usage: $0 [params] archive_dir file_name label startup_script [args]"
+    echo "Usage: $0 [params] archive_dir file_name label startup_command [args]"
     echo "params can be one or more of the following :"
     echo "    --version | -v     : Print out Makeself version number and exit"
     echo "    --help | -h        : Print out this help message"
@@ -125,7 +125,7 @@ MS_Usage()
     echo "    --copy             : Upon extraction, the archive will first copy itself to"
     echo "                         a temporary directory"
     echo "    --append           : Append more files to an existing Makeself archive"
-    echo "                         The label and startup scripts will then be ignored"
+    echo "                         The label and startup command will then be ignored"
     echo "    --target dir       : Extract directly to a target directory"
     echo "                         directory path can be either absolute or relative"
     echo "    --nooverwrite      : Do not extract the archive if the specified target directory exists"
@@ -136,7 +136,7 @@ MS_Usage()
     echo "    --nomd5            : Don't calculate an MD5 for archive"
     echo "    --nocrc            : Don't calculate a CRC for archive"
     echo "    --sha256           : Compute a SHA256 checksum for the archive"
-    echo "    --header file      : Specify location of the header script"
+    echo "    --header file      : Specify location of the header stub"
     echo "    --follow           : Follow the symlinks in the archive"
     echo "    --noprogress       : Do not show the progress during the decompression"
     echo "    --nox11            : Disable automatic spawn of a xterm"
@@ -150,9 +150,9 @@ MS_Usage()
     echo "                         instead of the current date."
     echo
     echo "    --keep-umask       : Keep the umask set to shell default, rather than overriding when executing self-extracting archive."
-    echo "    --export-conf      : Export configuration variables to startup_script"
+    echo "    --export-conf      : Export configuration variables to startup_command"
     echo
-    echo "Do not forget to give a fully qualified startup script name"
+    echo "Note: startup_command script invocations must be fully qualified"
     echo "(i.e. with a ./ prefix if inside the archive)."
     exit 1
 }

--- a/makeself.sh
+++ b/makeself.sh
@@ -76,22 +76,16 @@
 # Self-extracting archives created with this script are explictly NOT released under the term of the GPL
 #
 
-MS_VERSION=2.4.0
-MS_COMMAND="$0"
-unset CDPATH
-
-for f in "${1+"$@"}"; do
-    MS_COMMAND="$MS_COMMAND \\\\
-    \\\"$f\\\""
-done
-
-# For Solaris systems
-if test -d /usr/xpg4/bin; then
-    PATH=/usr/xpg4/bin:$PATH
-    export PATH
-fi
-
 # Procedures
+
+# https://www.etalabs.net/sh_tricks.html, "Shell-quoting arbitrary strings"
+quote() { printf %s\\n "$1" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/'/" ; }
+
+# https://www.etalabs.net/sh_tricks.html, "Working with arrays"
+save () {
+    for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
+        echo " "
+}
 
 MS_Usage()
 {
@@ -162,6 +156,16 @@ MS_Usage()
     echo "(i.e. with a ./ prefix if inside the archive)."
     exit 1
 }
+
+MS_VERSION=2.4.0
+MS_COMMAND="$(save $0 $@)"
+unset CDPATH
+
+# For Solaris systems
+if test -d /usr/xpg4/bin; then
+    PATH=/usr/xpg4/bin:$PATH
+    export PATH
+fi
 
 # Default settings
 if type gzip 2>&1 > /dev/null; then
@@ -459,10 +463,8 @@ else
     fi
 
     LABEL="$3"
-    SCRIPT="$4"
-    test "x$SCRIPT" = x || shift 1
     shift 3
-    SCRIPTARGS="$*"
+    STARTUP_COMMAND="$(save $@)"
 fi
 
 if test "$KEEP" = n -a "$CURRENT" = y; then

--- a/test/startupcommandtest
+++ b/test/startupcommandtest
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-THIS="$(readlink -f "$0")"
+THIS="$(realpath "$0")"
 HERE="$(dirname "${THIS}")"
 SUT="$(dirname "${HERE}")/makeself.sh"
 

--- a/test/startupcommandtest
+++ b/test/startupcommandtest
@@ -4,7 +4,7 @@ THIS="$(realpath "$0")"
 HERE="$(dirname "${THIS}")"
 SUT="$(dirname "${HERE}")/makeself.sh"
 
-testStartupCommand() {
+testStartupCommandWeirdNames() {
     (
         export TMPDIR="$(mktemp -d "${PWD}/tmpdir.XXXXXX")"
         
@@ -57,6 +57,73 @@ EOF
             "${file_name}"
             assertEqual $? 0
         done <"${weirdname_list}"
+        rm -rf "${TMPDIR}"
+    )
+}
+
+
+testStartupCommandShellExpr() {
+    (
+        export TMPDIR="$(mktemp -d "${PWD}/tmpdir.XXXXXX")"
+        local shellexpr_list="$(mktemp -t shellexpr_list.XXXXXX)"
+        cat >"${shellexpr_list}" <<'EOF'
+echo $PWD && echo "Second Line"
+sh -c 'echo $PWD && echo "Second Line"'
+EOF
+
+        while read shellexpr; do
+            local archive_dir="$(mktemp -dt archive_dir.XXXXXX)"
+            echo "${shellexpr}" | tee "${archive_dir}/shellexpr.txt"
+            local file_name="$(mktemp -ut "file_name.XXXXXX")"
+            "${SUT}" \
+                --nocomp --nox11 \
+                "${archive_dir}" "${file_name}" "The Label" "${shellexpr}"
+            assertEqual $? 0
+            "${file_name}" --list
+            assertEqual $? 0
+            "${file_name}" --info
+            assertEqual $? 0
+            "${file_name}" --dumpconf
+            assertEqual $? 0
+            "${file_name}"
+            assertEqual $? 0
+        done <"${shellexpr_list}"
+        rm -rf "${TMPDIR}"
+    )
+}
+
+testStartupCommandMoreArgs() {
+    (
+        export TMPDIR="$(mktemp -d "${PWD}/tmpdir.XXXXXX")"
+        local moreargs_list="$(mktemp -t moreargs_list.XXXXXX)"
+        cat >"${moreargs_list}" <<'EOF'
+echo $PWD && echo "Second Line" && ls
+sh -c 'echo $PWD && echo "Second Line" && ls'
+EOF
+
+        while read moreargs; do
+            local archive_dir="$(mktemp -dt archive_dir.XXXXXX)"
+            echo "${moreargs}" | tee "${archive_dir}/moreargs.txt"
+            local file_name="$(mktemp -ut "file_name.XXXXXX")"
+            "${SUT}" \
+                --nocomp --nox11 \
+                "${archive_dir}" "${file_name}" "The Label" "${moreargs}"
+            assertEqual $? 0
+            "${file_name}" --list
+            assertEqual $? 0
+            "${file_name}" --info
+            assertEqual $? 0
+            "${file_name}" --dumpconf
+            assertEqual $? 0
+            "${file_name}" --
+            assertEqual $? 0
+            "${file_name}" -- -l
+            assertEqual $? 0
+            "${file_name}" -- -la
+            assertEqual $? 0
+            "${file_name}" -- -lah
+            assertEqual $? 0
+        done <"${moreargs_list}"
         rm -rf "${TMPDIR}"
     )
 }

--- a/test/startupcommandtest
+++ b/test/startupcommandtest
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+THIS="$(readlink -f "$0")"
+HERE="$(dirname "${THIS}")"
+SUT="$(dirname "${HERE}")/makeself.sh"
+
+testStartupCommand() {
+    (
+        export TMPDIR="$(mktemp -d "${PWD}/tmpdir.XXXXXX")"
+        
+        local weirdname_list="$(mktemp -t weirdname_list.XXXXXX)"
+        cat >"${weirdname_list}" <<'EOF'
+_!_exclamation_mark
+_"_quotation_mark
+_#_octothorp
+_$_dollar
+_%_percent
+_&_ampersand
+_'_apostrophe
+_(_left_parenthesis
+_)_right_parenthesis
+_*_asterisk
+_+_plus
+_,_comma
+_-_hyphen
+_._full_stop
+_:_colon
+_;_semicolon
+_<_less_than
+_=_equals
+_>_greater_than
+_?_interrogative
+_@_ampersat
+_[_left_square_bracket
+_\_reverse_solidus
+_]_right_square_bracket
+_^_caret
+_{_left_bracket
+_|_vertical_bar
+_}_right_bracket
+EOF
+
+        while read weirdname; do
+            local archive_dir="$(mktemp -dt archive_dir.XXXXXX)"
+            echo "${weirdname}" | tee "${archive_dir}/${weirdname}.txt"
+            local file_name="$(mktemp -ut "file_name.XXXXXX")"
+            "${SUT}" \
+                --nocomp --nox11 \
+                "${archive_dir}" "${file_name}" "The Label" "ls -lah ${weirdname}.txt"
+            assertEqual $? 0
+            "${file_name}" --list
+            assertEqual $? 0
+            "${file_name}" --info
+            assertEqual $? 0
+            "${file_name}" --dumpconf
+            assertEqual $? 0
+            "${file_name}"
+            assertEqual $? 0
+        done <"${weirdname_list}"
+        rm -rf "${TMPDIR}"
+    )
+}
+
+source "${HERE}/bashunit/bashunit.bash"


### PR DESCRIPTION
* edit `makeself-header`:

  * change every `script` & `scriptargs` to `startup_command`

  * use `quote` (implemented in `makeself.sh`) to assign `startup_command`

  * change diagnostic references of "script" to "command"

* edit `makeself.sh`:

  * add Rich Felker's `quote` and `save`

  * move first instructions to follow last function definition

  * use `save` to assign `MS_COMMAND`

  * use `save` to assign `STARTUP_COMMAND`

* add `test/startupcommandtest` to test weird characters in files and startup
  commands