### PR TITLE
Remote unnecessary escaped single quote, which throws off certain tex…

### DIFF
--- a/makeself.sh
+++ b/makeself.sh
@@ -372,7 +372,7 @@ do
 	if ! shift 2; then MS_Help; exit 1; fi
         ;;
     --help-header)
-	HELPHEADER=`sed -e "s/'/'\\\\\''/g" $2`
+	HELPHEADER=`sed -e "s/'/'\\\\''/g" $2`
     if ! shift 2; then MS_Help; exit 1; fi
 	[ -n "$HELPHEADER" ] && HELPHEADER="$HELPHEADER
 "


### PR DESCRIPTION
…t editors with highlighting, like vim