### PR TITLE
Custom (de)compression via --{,de}compcmd options

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ makeself.sh [args] archive_dir file_name label startup_script [script_args]
     * **`--compress`** : Use the UNIX `compress` command to compress the data. This should be the default on all platforms that don't have gzip available.
     * **`--nocomp`** : Do not use any compression for the archive, which will then be an uncompressed TAR.
     * **`--complevel`** : Specify the compression level for gzip, bzip2, pbzip2, xz, lzo or lz4. (defaults to 9)
+    * **`--compcmd cmd`**: Use provided command to compress the archive from standard input to standard output. This option must be specified along with `--decompcmd` option.
+    * **`--decompcmd cmd`**: Use provided command to decompress the archive from standard input to standard output. This option must be specified along with `--compcmd` option.
     * **`--notemp`** : The generated archive will not extract the files to a temporary directory, but in a new directory created in the current directory. This is better to distribute software packages that may extract and compile by themselves (i.e. launch the compilation through the embedded script).
     * **`--current`** : Files will be extracted to the current directory, instead of in a subdirectory. This option implies `--notemp` above.
     * **`--follow`** : Follow the symbolic links inside of the archive directory, i.e. store the files that are being pointed to instead of the links themselves.

--- a/makeself.1
+++ b/makeself.1
@@ -54,6 +54,12 @@ Do not compress the data.
 .B --complevel lvl
 Specify the compression level for gzip,bzip2,pbzui2,xz,lzo or lz4
 .TP
+.B --compcmd cmd
+Use provided command to compress the archive from standard input to standard output. This option must be specified along with --decompcmd option.
+.TP
+.B --decompcmd cmd
+Use provided command to decompress the archive from standard input to standard output. This option must be specified along with --compcmd option.
+.TP
 .B --notemp
 The archive will create archive_dir in the current directory and 
 uncompress in ./archive_dir.

--- a/makeself.sh
+++ b/makeself.sh
@@ -125,6 +125,12 @@ MS_Usage()
     echo "    --nochown          : Do not give the target folder to the current user (default)"
     echo "    --chown            : Give the target folder to the current user recursively"
     echo "    --nocomp           : Do not compress the data"
+    echo "    --compcmd cmd"     : Use provided command to compress the archive from standard input"
+    echo "                         to standard output. This option must be specified along with"
+    echo "                         --decompcmd option."
+    echo "    --decompcmd cmd"   : Use provided command to decompress the archive from standard"
+    echo "                         input to standard output. This option must be specified along"
+    echo "                         with --compcmd option."
     echo "    --notemp           : The archive will create archive_dir in the"
     echo "                         current directory and uncompress in ./archive_dir"
     echo "    --needroot         : Check that the root user is extracting the archive before proceeding"
@@ -277,6 +283,16 @@ do
 	;;
     --complevel)
 	COMPRESS_LEVEL="$2"
+	if ! shift 2; then MS_Usage; exit 1; fi
+	;;
+    --compcmd)
+	COMPRESS=custom
+	GZIP_CMD="$2"
+	if ! shift 2; then MS_Usage; exit 1; fi
+	;;
+    --decompcmd)
+	COMPRESS=custom
+	GUNZIP_CMD="$2"
 	if ! shift 2; then MS_Usage; exit 1; fi
 	;;
     --nochown)
@@ -520,6 +536,16 @@ Unix)
 none)
     GZIP_CMD="cat"
     GUNZIP_CMD="cat"
+    ;;
+custom)
+    if test x"$GZIP_CMD" = x; then
+        echo "ERROR: --decompcmd was used without --compcmd" >&2
+        exit 1
+    fi
+    if test x"$GUNZIP_CMD" = x; then
+        echo "ERROR: --compcmd was used without --decompcmd" >&2
+        exit 1
+    fi
     ;;
 esac
 


### PR DESCRIPTION
This came from need to provide additional decryption parameters to GPG,
which is currently not possible. Instead of adding --gpg-decrypt-extra
option, this commit lets users provide custom commands (de)compression.

Example usage:

  ./makeself --compcmd "gpg -c" \
      --decompcmd "gpg -d --pinentry-mode=loopback" \
      . /tmp/sfx.sh installer ./run