### PR TITLE
Removed -title since its not compatible with all terminal types.

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -494,9 +494,9 @@ if test x"\$nox11" = xn; then
                 done
                 chmod a+x \$0 || echo Please add execution rights on \$0
                 if test \`echo "\$0" | cut -c1\` = "/"; then # Spawn a terminal!
-                    exec \$XTERM -title "\$label" -e "\$0" --xwin "\$initargs"
+                    exec \$XTERM -e "\$0" --xwin "\$initargs"
                 else
-                    exec \$XTERM -title "\$label" -e "./\$0" --xwin "\$initargs"
+                    exec \$XTERM -e "./\$0" --xwin "\$initargs"
                 fi
             fi
         fi

--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -494,9 +494,9 @@ if test x"\$nox11" = xn; then
                 done
                 chmod a+x \$0 || echo Please add execution rights on \$0
                 if test \`echo "\$0" | cut -c1\` = "/"; then # Spawn a terminal!
-                    exec \$XTERM -e "\$0" --xwin "\$initargs"
+                    exec \$XTERM -e "\$0 --xwin \$initargs"
                 else
-                    exec \$XTERM -e "./\$0" --xwin "\$initargs"
+                    exec \$XTERM -e "./\$0 --xwin \$initargs"
                 fi
             fi
         fi


### PR DESCRIPTION
This should solve #134 .

It also makes sure the script parameters are passed-through correctly. (i tested it by using --confirm with both gnome-terminal and xterm)

(a perfect regression test would test the installer against every supported terminal.)