### PR TITLE
Expose dirname of makeself executable

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -13,7 +13,7 @@ MD5="$MD5sum"
 SHA="$SHAsum"
 TMPROOT=\${TMPDIR:=/tmp}
 USER_PWD="\$PWD"; export USER_PWD
-RUNNING_DIR=\$(dirname \$0); export RUNNING_DIR
+ARCHIVE_DIR=\$(dirname \$0); export ARCHIVE_DIR
 
 label="$LABEL"
 script="$SCRIPT"

--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -13,6 +13,7 @@ MD5="$MD5sum"
 SHA="$SHAsum"
 TMPROOT=\${TMPDIR:=/tmp}
 USER_PWD="\$PWD"; export USER_PWD
+RUNNING_DIR=\$(dirname \$0); export RUNNING_DIR
 
 label="$LABEL"
 script="$SCRIPT"


### PR DESCRIPTION
Added `RUNNING_DIR` env variable which exposes the dirname of the makeself executable for startup scripts.