### PR TITLE
Printing content of license file (#197)

### DIFF
--- a/makeself.sh
+++ b/makeself.sh
@@ -327,7 +327,7 @@ do
 	;;
     --license)
         # We need to escape all characters having a special meaning in double quotes
-        LICENSE="$(echo "$2" | sed 's/./\\&/g' | xargs)"
+        LICENSE=$(sed 's/\\/\\\\/g; s/"/\\\"/g; s/`/\\\`/g; s/\$/\\\$/g' "$2")
         if ! shift 2; then MS_Usage; exit 1; fi
 	;;
     --follow)

--- a/test/whitespacelicense
+++ b/test/whitespacelicense
@@ -54,7 +54,7 @@ EOF
 
         # ...so do this instead:
         assertEqual \
-            "$(echo "${license_file}" | md5sum | cut -d' ' -f1)" \
+            "$(cat "${license_file}" | md5sum | cut -d' ' -f1)" \
             "$(echo "${license_text}" | md5sum | cut -d' ' -f1)"
     done
     rm -rf "${license_dir}" "${archive_dir}" "${file_name}"


### PR DESCRIPTION
Printing path to the file instead of content of the file was introduced
in 56c742bd90ebcb22feaff4d78ae4e62e72ffc7ad

Reverting parsing of the license file to the way it was before that
commit and escaping argument with quotes to address the original issue