### PR TITLE
Add cleanup script via `--cleanup file` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ makeself.sh [args] archive_dir file_name label startup_script [script_args]
     * **`--follow`** : Follow the symbolic links inside of the archive directory, i.e. store the files that are being pointed to instead of the links themselves.
     * **`--append`** _(new in 2.1.x)_: Append data to an existing archive, instead of creating a new one. In this mode, the settings from the original archive are reused (compression type, label, embedded script), and thus don't need to be specified again on the command line.
     * **`--header`** : Makeself 2.0 uses a separate file to store the header stub, called `makeself-header.sh`. By default, it is assumed that it is stored in the same location as makeself.sh. This option can be used to specify its actual location if it is stored someplace else.
+    * **`--cleanup`** : Specify a script that is run when execution is interrupted or finishes successfully. The script is executed with the same environment/arguments as `startup_script`
     * **`--copy`** : Upon extraction, the archive will first extract itself to a temporary directory. The main application of this is to allow self-contained installers stored in a Makeself archive on a CD, when the installer program will later need to unmount the CD and allow a new one to be inserted. This prevents "Filesystem busy" errors for installers that span multiple CDs.
     * **`--nox11`** : Disable the automatic spawning of a new terminal in X11.
     * **`--nowait`** : When executed from a new X11 terminal, disable the user prompt at the end of the script execution.
@@ -139,6 +140,7 @@ Archives generated with Makeself can be passed the following arguments:
   * **`--nochown`** : By default, a `chown -R` command is run on the target directory after extraction, so that all files belong to the current user. This is mostly needed if you are running as root, as tar will then try to recreate the initial user ownerships. You may disable this behavior with this flag.
   * **`--tar`** : Run the tar command on the contents of the archive, using the following arguments as parameter for the command.
   * **`--noexec`** : Do not run the embedded script after extraction.
+  * **`--noexec-cleanup`** : Do not run the embedded cleanup script.
   * **`--nodiskspace`** : Do not check for available disk space before attempting to extract.
 
 Any subsequent arguments to the archive will be passed as additional arguments to the embedded command. You must explicitly use the `--` special command-line construct before any such options to make sure that Makeself will not try to interpret them.

--- a/makeself.1
+++ b/makeself.1
@@ -73,6 +73,9 @@ Extract directly to a target directory. Directory path can be either absolute or
 .B --header file
 Specify location of the header script. 
 .TP
+.B --cleanup file
+Specify a cleanup script that executes on interrupt and when finished successfully.
+.TP
 .B --follow
 Follow the symlinks in the archive.
 .TP

--- a/makeself.sh
+++ b/makeself.sh
@@ -143,6 +143,7 @@ MS_Usage()
     echo "    --nocrc            : Don't calculate a CRC for archive"
     echo "    --sha256           : Compute a SHA256 checksum for the archive"
     echo "    --header file      : Specify location of the header script"
+    echo "    --cleanup file     : Specify a cleanup script that executes on interrupt and when finished successfully."
     echo "    --follow           : Follow the symlinks in the archive"
     echo "    --noprogress       : Do not show the progress during the decompression"
     echo "    --nox11            : Disable automatic spawn of a xterm"
@@ -325,6 +326,10 @@ do
 	HEADER="$2"
         if ! shift 2; then MS_Usage; exit 1; fi
 	;;
+    --cleanup)
+    CLEANUP_SCRIPT="$2"
+        if ! shift 2; then MS_Usage; exit 1; fi
+    ;;
     --license)
         # We need to escape all characters having a special meaning in double quotes
         LICENSE=$(sed 's/\\/\\\\/g; s/"/\\\"/g; s/`/\\\`/g; s/\$/\\\$/g' "$2")


### PR DESCRIPTION
Use case example:
During execution a temporary Docker image is loaded and started, but
must be stopped and removed before returning to the controlling
terminal. Since this must happen in both exit cases (normal exit, and
signal capture handling) and since `trap` handling does not appear to work inside
`startup_script`, an alternative is needed.

Specifying `makeself ... --cleanup ./cleanup.sh ...` allows using an
included script to stop and remove the image in both situations.

The cleanup script is provided the same arguments that are given to
`startup_script` and is executed from the same working directory.