### PR TITLE
Fix archive dir

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -14,7 +14,7 @@ SHA="$SHAsum"
 TMPROOT=\${TMPDIR:=/tmp}
 USER_PWD="\$PWD"
 export USER_PWD
-ARCHIVE_DIR=\`dirname \$0\`
+ARCHIVE_DIR=\`dirname "\$0"\`
 export ARCHIVE_DIR
 
 label="$LABEL"

--- a/test/variabletest
+++ b/test/variabletest
@@ -24,4 +24,30 @@ testArchiveDir()
   assertEqual "${actual_archive_dir}" "${ans}"
 }
 
+testTmpRoot()
+{
+  setupTests TMPROOT
+  local ans="${temp}"$'/complicated\n dir\twith  spaces'
+  mkdir -p "${ans}"
+
+  actual_tmp_root="$(TMPDIR="${ans}" "./makeself-test.run" --quiet)"
+
+  ans="$(TMPROOT="${ans}"; declare -p TMPROOT)"
+  assertEqual "${actual_tmp_root}" "${ans}"
+}
+
+testUserPWD()
+{
+  setupTests USER_PWD
+  local ans="${temp}"$'/complicated\n dir\twith  spaces'
+  mkdir -p "${ans}"
+  cd "${ans}"
+
+  actual_user_pwd="$("${temp}/makeself-test.run" --quiet)"
+
+  ans="$(export USER_PWD="${ans}"; declare -p USER_PWD)"
+  assertEqual "${actual_user_pwd}" "${ans}"
+}
+
+
 source bashunit/bashunit.bash

--- a/test/variabletest
+++ b/test/variabletest
@@ -9,7 +9,8 @@ setupTests() {
   mkdir archive
   touch archive/file
 
-  $SUT archive makeself-test.run "Test $1" declare -p "${1}"
+  # $SUT archive makeself-test.run "Test $1" declare -p "${1}"
+  $SUT archive makeself-test.run "Test $1" echo \\\"\${${1}}\\\"
 }
 
 testArchiveDir()
@@ -20,7 +21,6 @@ testArchiveDir()
   mv ./makeself-test.run "${ans}/"
   actual_archive_dir="$("${ans}/makeself-test.run" --quiet)"
 
-  ans="$(export ARCHIVE_DIR="${ans}"; declare -p ARCHIVE_DIR)"
   assertEqual "${actual_archive_dir}" "${ans}"
 }
 
@@ -32,7 +32,6 @@ testTmpRoot()
 
   actual_tmp_root="$(TMPDIR="${ans}" "./makeself-test.run" --quiet)"
 
-  ans="$(TMPROOT="${ans}"; declare -p TMPROOT)"
   assertEqual "${actual_tmp_root}" "${ans}"
 }
 
@@ -45,7 +44,6 @@ testUserPWD()
 
   actual_user_pwd="$("${temp}/makeself-test.run" --quiet)"
 
-  ans="$(export USER_PWD="${ans}"; declare -p USER_PWD)"
   assertEqual "${actual_user_pwd}" "${ans}"
 }
 

--- a/test/variabletest
+++ b/test/variabletest
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+SUT=$(realpath $(dirname $0)/../makeself.sh)
+SOURCE=$(realpath ..)
+
+setupTests() {
+  temp=`mktemp -d -t XXXXX`
+  cd "$temp"
+  mkdir archive
+  touch archive/file
+
+  $SUT archive makeself-test.run "Test $1" declare -p "${1}"
+}
+
+testArchiveDir()
+{
+  setupTests ARCHIVE_DIR
+  local ans=$'./complicated\n dir\twith  spaces'
+  mkdir "${ans}"
+  mv ./makeself-test.run "${ans}/"
+  actual_archive_dir="$("${ans}/makeself-test.run" --quiet)"
+
+  ans="$(export ARCHIVE_DIR="${ans}"; declare -p ARCHIVE_DIR)"
+  assertEqual "${actual_archive_dir}" "${ans}"
+}
+
+source bashunit/bashunit.bash


### PR DESCRIPTION
I noticed that `ARCHIVE_DIR` was missing some quotes, so I added a unit test and solution for this.

I wasn't sure how you want the final quotes to be, it seemed a little inconsistent, so I just left them alone. I always prefer to put the quotes in, but that's just my style.

```bash
CRCsum="$CRCsum"
MD5="$MD5sum"
SHA="$SHAsum"
TMPROOT=\${TMPDIR:=/tmp}
USER_PWD="\$PWD"
export USER_PWD
ARCHIVE_DIR=\`dirname "\$0"\`
export ARCHIVE_DIR
```

Could become

```bash
CRCsum="$CRCsum"
MD5="$MD5sum"
SHA="$SHAsum"
TMPROOT="\${TMPDIR:=/tmp}"
USER_PWD="\$PWD"
export USER_PWD
ARCHIVE_DIR="\`dirname "\$0"\`"
export ARCHIVE_DIR
```

However the $0 _required_ quotes to work in situations where the directory had white space in it.

I can add the more quotes if you prefer. Just let me know!
