### PR TITLE
Test dd features before executing

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -97,9 +97,14 @@ MS_dd()
 {
     blocks=\`expr \$3 / 1024\`
     bytes=\`expr \$3 % 1024\`
-    dd if="\$1" ibs=\$2 skip=1 obs=1024 conv=sync 2> /dev/null | \\
-    { test \$blocks -gt 0 && dd ibs=1024 obs=1024 count=\$blocks ; \\
-      test \$bytes  -gt 0 && dd ibs=1 obs=1024 count=\$bytes ; } 2> /dev/null
+    # Test for ibs, obs and conv feature
+    if dd if=/dev/zero of=/dev/null count=1 ibs=512 obs=512 conv=sync 2> /dev/null; then
+        dd if="\$1" ibs=\$2 skip=1 obs=1024 conv=sync 2> /dev/null | \\
+        { test \$blocks -gt 0 && dd ibs=1024 obs=1024 count=\$blocks ; \\
+          test \$bytes  -gt 0 && dd ibs=1 obs=1024 count=\$bytes ; } 2> /dev/null
+    else
+        dd if="\$1" bs=\$2 skip=1 2> /dev/null
+    fi
 }
 
 MS_dd_Progress()


### PR DESCRIPTION
Some dd implementations may lack some features. The most prominent is
busybox configured with a minimal subset of dd. This minimal
configuration is sometimes used with Yocto/OpenEmbedded systems and
seems to be the default configuration.

Check dd for these features by executing dd, reading /dev/zero and
writing to /dev/null with the ibs, obs and conv options. Use the
block/bytes writing scheme in success and a simpler dd call otherwise.

This commit fixes megastep/makeself#161.