### PR TITLE
Pass threads option to zstd compressor

### DIFF
--- a/makeself.sh
+++ b/makeself.sh
@@ -521,6 +521,9 @@ pigz)
     ;;
 zstd)
     GZIP_CMD="zstd -$COMPRESS_LEVEL"
+    if test $THREADS -ne $DEFAULT_THREADS; then # Leave as the default if threads not indicated
+        GZIP_CMD="$GZIP_CMD --threads=$THREADS"
+    fi
     GUNZIP_CMD="zstd -cd"
     ;;
 pbzip2)


### PR DESCRIPTION
Zstd supports `--threads` since version 1.2.0 (May 2017) according to https://github.com/facebook/zstd/blob/dev/CHANGELOG

Setting `--threads 0` greatly improves compression times.