### PR TITLE
fix #254: allow and sanitize lsm files without trailing newlines

### DIFF
--- a/makeself.sh
+++ b/makeself.sh
@@ -407,7 +407,7 @@ do
 	shift
 	;;
     --lsm)
-	LSM_CMD="cat \"$2\" >> \"\$archname\""
+	LSM_CMD="awk 1 \"$2\" >> \"\$archname\""
     shift 2 || { MS_Usage; exit 1; }
 	;;
     --packaging-date)

--- a/test/lsmtest
+++ b/test/lsmtest
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# makeself/test/lsmtest
+
+set -eu
+
+THIS="$(realpath "$0")"
+HERE="$(dirname "${THIS}")"
+SRCDIR="$(dirname "${HERE}")"
+
+################################################################################
+
+# Take makeself options, generate a predefined archive, print --lsm to stdout.
+#
+# $@ : makeself options
+withlsm() (
+    cd "${SRCDIR}"
+    mkdir -p lsmtest
+    ./makeself.sh "$@" ./lsmtest ./lsmtest.run lsmtest ls -lah >/dev/null 2>&1
+    assertEqual "$?" 0 >&2
+    ./lsmtest.run --lsm
+    assertEqual "$?" 0 >&2
+    rm -rf lsmtest lsmtest.run
+)
+
+test_lsm_empty() {
+    printf '' >lsm_empty.txt
+    wc lsm_empty.txt
+    withlsm --lsm lsm_empty.txt
+    rm -f lsm_empty.txt
+}
+
+test_lsm_one_line() {
+    printf 'one line\n' >lsm_one_line.txt
+    withlsm --lsm lsm_one_line.txt
+    rm -f lsm_one_line.txt
+}
+
+test_lsm_one_line_without_nl() {
+    printf 'one line without nl' >lsm_one_line_without_nl.txt
+    withlsm --lsm lsm_one_line_without_nl.txt
+    rm -f lsm_one_line_without_nl.txt
+}
+
+################################################################################
+
+# shellcheck disable=SC1091
+source "${HERE}/bashunit/bashunit.bash"


### PR DESCRIPTION
* edit `makeself.sh`: change the LSM_CMD from `cat` to `awk 1` when generating
  the LSM content into the archive

* add `test/lsmtest`: verify the correct functionality of three different LSM
  files; i.e., empty, single line, and single line without trailing newline.