### PR TITLE
fix 282: 'df -kP' -> 'df -k'

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -92,7 +92,7 @@ MS_PrintLicense()
 MS_diskspace()
 {
 	(
-	df -kP "\$1" | tail -1 | awk '{ if (\$4 ~ /%/) {print \$3} else {print \$4} }'
+	df -k "\$1" | tail -1 | awk '{ if (\$4 ~ /%/) {print \$3} else {print \$4} }'
 	)
 }
 


### PR DESCRIPTION
Because VMware ESXi version 6.5 ships 'df' as a (very) non-compliant python script that (surprise) doesn't support your fancy POSIX output format.

Further reading:

* https://git.busybox.net/busybox/tree/coreutils/df.c
* https://github.com/landley/toybox/blob/master/toys/posix/df.c
* https://pubs.opengroup.org/onlinepubs/9699919799/utilities/df.html