### PR TITLE
Make the script executable before attempting to run it

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -694,9 +694,11 @@ if test x"\$script" != x; then
 		MS_Printf "OK to execute: \$script \$scriptargs \$* ? [Y/n] "
 		read yn
 		if test x"\$yn" = x -o x"\$yn" = xy -o x"\$yn" = xY; then
+			chmod +x "\$script"
 			eval "\"\$script\" \$scriptargs \"\\\$@\""; res=\$?;
 		fi
     else
+		chmod +x "\$script"
 		eval "\"\$script\" \$scriptargs \"\\\$@\""; res=\$?
     fi
     if test "\$res" -ne 0; then


### PR DESCRIPTION
I could not get the script to run without this change. This should potentially resolve #146 and possibly others. The downside is this will make scenarios like passing "bash install.sh" no longer valid, and there is no check for that.