### PR TITLE
Remove stale makeself.lsm reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ makeself.sh [args] archive_dir file_name label startup_script [script_args]
     * **`--nowait`** : When executed from a new X11 terminal, disable the user prompt at the end of the script execution.
     * **`--nomd5`** and **`--nocrc`** : Disable the creation of a MD5 / CRC checksum for the archive. This speeds up the extraction process if integrity checking is not necessary.
     * **`--sha256`** : Adds a SHA256 checksum for the archive. This is in addition to the MD5 / CRC checksums unless `--nomd5` is also used.
-    * **`--lsm` _file_** : Provide a Linux Software Map (LSM) file to makeself, that will be embedded in the generated archive. LSM files are describing a software package in a way that is easily parseable. The LSM entry can then be later retrieved using the `--lsm` argument to the archive. An example of a LSM file is provided with Makeself.
+    * **`--lsm` _file_** : Provide a Linux Software Map (LSM) file to makeself, that will be embedded in the generated archive. LSM files are describing a software package in a way that is easily parseable. The LSM entry can then be later retrieved using the `--lsm` argument to the archive.
     * **`--tar-format opt`** : Specify the tar archive format (default is ustar); you may use any value accepted by your tar command (such as posix, v7, etc).
     * **`--tar-extra opt`** : Append more options to the tar command line.
 


### PR DESCRIPTION
I noticed the inconsistency as I was reviewing commits since 2.4.5, working on the 2.5.0 update on Fedora.