### PR TITLE
Update makeself-header.sh to better handle relative paths and provide…

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -15,8 +15,11 @@ SIGNATURE="$Signature"
 TMPROOT=\${TMPDIR:=/tmp}
 USER_PWD="\$PWD"
 export USER_PWD
-ARCHIVE_DIR=\`dirname "\$0"\`
+ARCHIVE_DIR=\$( cd -- "\$(dirname "\$0")" >/dev/null 2>&1 ; echo \$PWD )
 export ARCHIVE_DIR
+ARCHIVE_BASE=\`basename "\$0"\`
+export ARCHIVE_BASE
+
 
 label="$LABEL"
 script="$SCRIPT"


### PR DESCRIPTION
… a launching script name to a startup_script

Update the ARCHIVE_DIR variable to provide an absolute path even when the makeself script is launched with a relative path. An absolute path is needed when the startup script is ask to place folder and files in a directory relative to the makeself script location.

Add the ARCHIVE_BASE variable. This provides the name of the originating makeself script. This is useful to provide feedback to the user in for example 'usage' messages.