### PR TITLE
Feature: Allow extra options to compressor

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ makeself.sh [args] archive_dir file_name label startup_script [script_args]
     * **`--compress`** : Use the UNIX `compress` command to compress the data. This should be the default on all platforms that don't have gzip available.
     * **`--nocomp`** : Do not use any compression for the archive, which will then be an uncompressed TAR.
     * **`--complevel`** : Specify the compression level for gzip, bzip2, pbzip2, zstd, xz, lzo or lz4. (defaults to 9)
+    * **`--comp-extra`** : Append more options to the compressor's command line.
     * **`--threads`** : Specify the number of threads to be used by compressors that support parallelization. Omit to use compressor's default. Most useful (and required) for opting into xz's threading, usually with `--threads=0` for all available cores. pbzip2 and pigz are parallel by default, and setting this value allows limiting the number of threads they use.
     * **`--notemp`** : The generated archive will not extract the files to a temporary directory, but in a new directory created in the current directory. This is better to distribute software packages that may extract and compile by themselves (i.e. launch the compilation through the embedded script).
     * **`--current`** : Files will be extracted to the current directory, instead of in a subdirectory. This option implies `--notemp` above.

--- a/makeself.1
+++ b/makeself.1
@@ -74,6 +74,9 @@ Do not compress the data.
 .B --complevel lvl
 Specify the compression level for gzip, bzip2, pbzip2, xz, zstd, lzo or lz4. Defaults to 9.
 .TP
+.B --comp-extra opt
+Append more options to the compressor's command line.
+.TP
 .B --threads num
 Specify the number of threads to be used by compressors that support parallelization.
 .TP

--- a/makeself.sh
+++ b/makeself.sh
@@ -53,6 +53,7 @@ MS_Usage()
     echo "    --lz4              : Compress using lz4 instead of gzip"
     echo "    --compress         : Compress using the UNIX 'compress' command"
     echo "    --complevel lvl    : Compression level for gzip pigz zstd xz lzo lz4 bzip2 pbzip2 and bzip3 (default 9)"
+    echo "    --comp-extra       : Append extra options to the chosen compressor"
     echo "    --threads thds     : Number of threads to be used by compressors that support parallelization."
     echo "                         Omit to use compressor's default. Most useful (and required) for opting"
     echo "                         into xz's threading, usually with '--threads=0' for all available cores."
@@ -134,6 +135,7 @@ PASSWD=""
 PASSWD_SRC=""
 OPENSSL_NO_MD=n
 COMPRESS_LEVEL=9
+COMP_EXTRA=""
 DEFAULT_THREADS=123456 # Sentinel value
 THREADS=$DEFAULT_THREADS
 KEEP=n
@@ -251,6 +253,10 @@ do
 	;;
     --complevel)
 	COMPRESS_LEVEL="$2"
+    shift 2 || { MS_Usage; exit 1; }
+	;;
+    --comp-extra)
+	COMP_EXTRA="$2"
     shift 2 || { MS_Usage; exit 1; }
 	;;
     --threads)
@@ -547,6 +553,10 @@ none)
     GUNZIP_CMD="cat"
     ;;
 esac
+
+if test x"$COMP_EXTRA" != "x"; then
+    GZIP_CMD="$GZIP_CMD $COMP_EXTRA"
+fi
 
 if test x"$ENCRYPT" = x"openssl"; then
     if test x"$APPEND" = x"y"; then

--- a/test/compextratest
+++ b/test/compextratest
@@ -27,20 +27,6 @@ testCompExtraOpts() {
   tearDown
 }
 
-# Negative test: ensure failures are detected when invalid compressor
-# extras are specified.
-testCompExtraOptsInvalid() {
-  setupTests
-
-  comp_extra="-x" # -x is an invalid gzip option
-  ${SUT} --comp-extra "$comp_extra" src src.sh alabel startup.sh
-
-  assertNotEquals $? 0
-
-  tearDown
-}
-
-
 # Load and run shUnit2.
 source "./shunit2/shunit2"
 

--- a/test/compextratest
+++ b/test/compextratest
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -eu
+THIS="$(readlink -f "$0")"
+THISDIR="$(dirname "${THIS}")"
+SUT="$(dirname "${THISDIR}")/makeself.sh"
+
+setupTests() {
+  temp=$(mktemp -d -t XXXXX)
+  pushd "${temp}"
+  mkdir src
+  echo "echo This is a test" > src/startup.sh
+}
+
+tearDown() {
+  popd
+  rm -rf "${temp}"
+}
+
+testCompExtraOpts() {
+  setupTests
+
+  comp_extra="--no-name"
+  ${SUT} --comp-extra "$comp_extra" src src.sh alabel startup.sh
+
+  assertEquals $? 0
+
+  tearDown
+}
+
+# Negative test: ensure failures are detected when invalid compressor
+# extras are specified.
+testCompExtraOptsInvalid() {
+  setupTests
+
+  comp_extra="-x" # -x is an invalid gzip option
+  ${SUT} --comp-extra "$comp_extra" src src.sh alabel startup.sh
+
+  assertNotEquals $? 0
+
+  tearDown
+}
+
+
+# Load and run shUnit2.
+source "./shunit2/shunit2"
+


### PR DESCRIPTION
This feature adds a new command line parameter, `--comp-extra`, which functions similarly to `--tar-extra`, in that it allows a user to add extra parameters to whichever compressor they have chosen to use.

The basis for this feature was to allow passing `--no-name` to gzip, as part of a quest to make fully reproducible makeself archives.