### PR TITLE
Only skip offset

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -130,7 +130,7 @@ MS_dd_Progress()
     blocks=\`expr \$length / \$bsize\`
     bytes=\`expr \$length % \$bsize\`
     (
-        dd ibs=\$offset skip=1 count=1 2>/dev/null
+        dd ibs=\$offset skip=1 count=0 2>/dev/null
         pos=\`expr \$pos \+ \$bsize\`
         MS_Printf "     0%% " 1>&2
         if test \$blocks -gt 0; then


### PR DESCRIPTION
The dd option skip seeks the input stream. An additional count reads the specified bytes from the input and outputs it. This causes the last bytes read to be incorrect.