### PR TITLE
feat :sparkles: Access archive name from script

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -17,6 +17,8 @@ USER_PWD="\$PWD"
 export USER_PWD
 ARCHIVE_DIR=\`dirname "\$0"\`
 export ARCHIVE_DIR
+ARCHIVE_NAME=\`basename "\$0"\`
+export ARCHIVE_NAME
 
 label="$LABEL"
 script="$SCRIPT"

--- a/test/variabletest
+++ b/test/variabletest
@@ -3,6 +3,7 @@ set -eu
 THIS="$(readlink -f "$0")"
 THISDIR="$(dirname "${THIS}")"
 SUT="$(dirname "${THISDIR}")/makeself.sh"
+ARCHIVE_NAME="makeself-test.run"
 
 setupTests() {
   temp=`mktemp -d -t XXXXX`
@@ -11,7 +12,7 @@ setupTests() {
   touch archive/file
 
   # $SUT archive makeself-test.run "Test $1" declare -p "${1}"
-  $SUT archive makeself-test.run "Test $1" echo \\\"\${${1}}\\\"
+  $SUT archive "${ARCHIVE_NAME}" "Test $1" echo \\\"\${${1}}\\\"
 }
 
 testArchiveDir()
@@ -46,6 +47,18 @@ testUserPWD()
   actual_user_pwd="$("${temp}/makeself-test.run" --quiet)"
 
   assertEquals "${actual_user_pwd}" "${ans}"
+}
+
+testArchiveName()
+{
+  setupTests ARCHIVE_NAME
+  local ans="${temp}"$'/complicated\n dir\twith  spaces'
+  mkdir -p "${ans}"
+  cd "${ans}"
+
+  actual_archive_name="$("${temp}/makeself-test.run" --quiet)"
+
+  assertEquals "${actual_archive_name}" "${ARCHIVE_NAME}"
 }
 
 # Load and run shUnit2.

--- a/test/variabletest
+++ b/test/variabletest
@@ -3,16 +3,16 @@ set -eu
 THIS="$(readlink -f "$0")"
 THISDIR="$(dirname "${THIS}")"
 SUT="$(dirname "${THISDIR}")/makeself.sh"
-ARCHIVE_NAME="makeself-test.run"
 
 setupTests() {
   temp=`mktemp -d -t XXXXX`
   cd "$temp"
   mkdir archive
   touch archive/file
+  archive_name=${2:-"makeself-test.run"}
 
   # $SUT archive makeself-test.run "Test $1" declare -p "${1}"
-  $SUT archive "${ARCHIVE_NAME}" "Test $1" echo \\\"\${${1}}\\\"
+  $SUT archive "${archive_name}" "Test $1" echo \\\"\${${1}}\\\"
 }
 
 testArchiveDir()
@@ -51,14 +51,12 @@ testUserPWD()
 
 testArchiveName()
 {
-  setupTests ARCHIVE_NAME
-  local ans="${temp}"$'/complicated\n dir\twith  spaces'
-  mkdir -p "${ans}"
-  cd "${ans}"
+  local ans="`mktemp -u XXXXXX`.run"
+  setupTests ARCHIVE_NAME "${ans}"
 
-  actual_archive_name="$("${temp}/makeself-test.run" --quiet)"
+  actual_archive_name="$("${temp}/${ans}" --quiet)"
 
-  assertEquals "${actual_archive_name}" "${ARCHIVE_NAME}"
+  assertEquals "${actual_archive_name}" "${ans}"
 }
 
 # Load and run shUnit2.


### PR DESCRIPTION
# Export Archive name

Added the variable `ARCHIVE_NAME` to the makeself header to give the start script access not only to the archive directory but also it's name.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose `ARCHIVE_NAME` (basename of the archive) to the start script and add tests validating it.
> 
> - **Core**:
>   - Export `ARCHIVE_NAME=\`basename "$0"\`` in `makeself-header.sh` to expose the archive file name to the embedded script.
> - **Tests (`test/variabletest`)**:
>   - Use `ARCHIVE_NAME` when creating the test archive.
>   - Add `testArchiveName` to assert the exposed `ARCHIVE_NAME` matches the expected value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8dc6b13102667c2427b7e8d6726a963269b60c43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->