### PR TITLE
Fix #349: pre-extraction script execution in combination with --notemp

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -327,7 +327,8 @@ MS_Preextract()
     echo "\$preextract" | base64 -d > "\$prescript"
     chmod a+x "\$prescript"
 
-    (cd "\$tmpdir"; eval "\"\$prescript\" \$scriptargs \"\\\$@\""); res=\$?
+    prescript_basename=\$(basename "\$prescript")
+    (cd "\$tmpdir"; eval "\"./\$prescript_basename\" \$scriptargs \"\\\$@\""); res=\$?
 
     rm -f "\$prescript"
     if test \$res -ne 0; then

--- a/test/preextracttest
+++ b/test/preextracttest
@@ -80,6 +80,18 @@ testPreextractArgs() {
   assertEquals 0 $?
 }
 
+testPreextractNotemp() {
+  echo 'echo Validating pre-extraction script execution.' > preextract.sh
+  ${SUT} --notemp --nox11 --preextract preextract.sh src src_notemp.sh alabel ./startup.sh
+  assertEquals 0 $?
+
+  ./src_notemp.sh
+  assertEquals 0 $?
+
+  ./src_notemp.sh | grep -qF 'Validating pre-extraction script execution.'
+  assertEquals 0 $?
+}
+
 testPreextractEnvPassing() {
   # imitate user input
   echo 'echo "export INSTALLATION_DIR=/usr/bin" > preextract.env' > preextract.sh


### PR DESCRIPTION
- MS_Preextract creates temp script in $location rather than $tmpdir
- New test case to verify the fix in test/preextracttest