### PR TITLE
Replace 'ibs=' option with 'bs=' for better portability.

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -137,7 +137,7 @@ MS_dd_Progress()
     blocks=\`expr \$length / \$bsize\`
     bytes=\`expr \$length % \$bsize\`
     (
-        dd ibs=\$offset skip=1 count=1 2>/dev/null
+        dd bs=\$offset skip=1 count=1 2>/dev/null
         pos=\`expr \$pos \+ \$bsize\`
         MS_Printf "     0%% " 1>&2
         if test \$blocks -gt 0; then


### PR DESCRIPTION
I recently had to debug a failing _makeself_ install (another case of 'Error in MD5 checksums') which after a little time and effort was traced to a minimal busybox `dd` implementation that lacked the `ibs=` option. Since the only place where `ibs=` is required is in the `MS_dd_Progress()` function, and the output size is not applicable, my fix was to simply replace the `ibs=` option with `bs=`. As the `bs=` option is already being used several lines below this first call which jumps to the tar data, this should not break any new systems.

Related to #161
Somewhat related to #332